### PR TITLE
Implement basic authentication

### DIFF
--- a/bd_iglesia
+++ b/bd_iglesia
@@ -78,6 +78,14 @@ CREATE TABLE contribucion (
     FOREIGN KEY (miembro_id) REFERENCES miembro(id) ON DELETE CASCADE
 );
 
+-- Tabla de usuarios para autenticación
+CREATE TABLE usuario (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    rol VARCHAR(20) NOT NULL
+);
+
 --POBLADA DE TABLAS
 -- Insertar ministerios
 INSERT INTO ministerio (nombre, descripcion) VALUES
@@ -126,6 +134,10 @@ INSERT INTO contribucion (evento_id, miembro_id, tipo, monto) VALUES
 (1, 1, 'Diezmo', 100.00),
 (2, 2, 'Ofrenda', 50.00),
 (3, 3, 'Donacion', 25.00);
+
+-- Usuario administrador por defecto (password: admin123)
+INSERT INTO usuario (username, password, rol) VALUES
+('admin', '$2b$12$8/GBmKHHXJsDhv1QTjr3qe7Hv6q69Kvw.iRt0yTbpqaDiN85WSI7q', 'admin');
 
 
 

--- a/controlador/AuthProxy.php
+++ b/controlador/AuthProxy.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/IController.php';
+
+class AuthProxy implements IController {
+    private $controller;
+
+    public function __construct(IController $controller) {
+        $this->controller = $controller;
+    }
+
+    public function handleRequest() {
+        if (isset($_SESSION['usuario'])) {
+            $this->controller->handleRequest();
+        } else {
+            header('Location: index.php?controller=auth&action=login');
+            exit;
+        }
+    }
+}
+?>

--- a/controlador/CAsignacion_Ministerio.php
+++ b/controlador/CAsignacion_Ministerio.php
@@ -3,8 +3,9 @@ require_once __DIR__ . '/../modelo/MAsignacion_Ministerio.php';
 require_once __DIR__ . '/../modelo/MMiembro.php';
 require_once __DIR__ . '/../modelo/MMinisterio.php';
 require_once __DIR__ . '/../vista/congregacion/VAsignacion_Ministerio.php';
+require_once __DIR__ . '/IController.php';
 
-class CAsignacion_Ministerio
+class CAsignacion_Ministerio implements IController
 {
     private $modelo;
     private $miembroModel;

--- a/controlador/CAuth.php
+++ b/controlador/CAuth.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/IController.php';
+require_once __DIR__ . '/../modelo/MUsuario.php';
+require_once __DIR__ . '/../vista/auth/VLogin.php';
+
+class CAuth implements IController {
+    private $modelo;
+    private $vista;
+
+    public function __construct() {
+        $this->modelo = new MUsuario();
+        $this->vista = new VLogin();
+    }
+
+    public function handleRequest() {
+        $action = $_GET['action'] ?? 'login';
+        switch ($action) {
+            case 'login':
+                $this->login();
+                break;
+            case 'logout':
+                $this->logout();
+                break;
+            default:
+                $this->login();
+                break;
+        }
+    }
+
+    private function login() {
+        $error = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $username = $_POST['username'] ?? '';
+            $password = $_POST['password'] ?? '';
+            $usuario = $this->modelo->obtenerUsuarioPorUsername($username);
+            if ($usuario && password_verify($password, $usuario['password'])) {
+                $_SESSION['usuario'] = $usuario;
+                header('Location: index.php');
+                exit;
+            } else {
+                $error = 'Credenciales inválidas';
+            }
+        }
+        $this->vista->render($error);
+    }
+
+    private function logout() {
+        session_destroy();
+        header('Location: index.php');
+        exit;
+    }
+}
+?>

--- a/controlador/CCargo.php
+++ b/controlador/CCargo.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__ . '/../modelo/MCargo.php';
 require_once __DIR__ . '/../vista/congregacion/VCargo.php';
+require_once __DIR__ . '/IController.php';
 
-class CCargo {
+class CCargo implements IController {
     private $modelo;
     private $vista;
 

--- a/controlador/CCategoria_evento.php
+++ b/controlador/CCategoria_evento.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__ . '/../modelo/MCategoria_evento.php';
 require_once __DIR__ . '/../vista/eventos/VCategoria_evento.php';
+require_once __DIR__ . '/IController.php';
 
-class CCategoria_evento {
+class CCategoria_evento implements IController {
     private $modelo;
     private $vista;
 

--- a/controlador/CContribucion.php
+++ b/controlador/CContribucion.php
@@ -3,8 +3,9 @@ require_once __DIR__ . '/../modelo/MContribucion.php';
 require_once __DIR__ . '/../modelo/MEvento.php';
 require_once __DIR__ . '/../modelo/MMiembro.php';
 require_once __DIR__ . '/../vista/contribuciones/VContribucion.php';
+require_once __DIR__ . '/IController.php';
 
-class CContribucion {
+class CContribucion implements IController {
     private $vista;
 
     private $modelo;

--- a/controlador/CEvento.php
+++ b/controlador/CEvento.php
@@ -5,8 +5,9 @@ require_once __DIR__ . '/../modelo/MMiembro.php';
 require_once __DIR__ . '/../modelo/MCargo.php';
 require_once __DIR__ . '/../modelo/MAsistencia_Evento.php';
 require_once __DIR__ . '/../vista/eventos/VEvento.php';
+require_once __DIR__ . '/IController.php';
 
-class CEvento {
+class CEvento implements IController {
     private $vista;
 
     private $modelo;

--- a/controlador/CMiembro.php
+++ b/controlador/CMiembro.php
@@ -2,8 +2,9 @@
 require_once __DIR__ . '/../modelo/MMiembro.php';
 require_once __DIR__ . '/../modelo/MCargo.php';
 require_once __DIR__ . '/../vista/congregacion/VMiembro.php';
+require_once __DIR__ . '/IController.php';
 
-class CMiembro {
+class CMiembro implements IController {
     private $modelo;
     private $cargoModel;
     private $vista;

--- a/controlador/CMinisterio.php
+++ b/controlador/CMinisterio.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__ . '/../modelo/MMinisterio.php';
 require_once __DIR__ . '/../vista/congregacion/VMinisterio.php';
+require_once __DIR__ . '/IController.php';
 
-class CMinisterio {
+class CMinisterio implements IController {
     private $modelo;
     private $vista;
 

--- a/controlador/IController.php
+++ b/controlador/IController.php
@@ -1,0 +1,5 @@
+<?php
+interface IController {
+    public function handleRequest();
+}
+?>

--- a/index.php
+++ b/index.php
@@ -3,6 +3,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require_once 'config/conexion.php';
+session_start();
 
 $controller = $_GET['controller'] ?? null;
 
@@ -13,6 +14,10 @@ if ($controller) {
     if (file_exists($controllerFile)) {
         require_once $controllerFile;
         $controllerInstance = new $controllerClass();
+        if ($controller !== 'auth') {
+            require_once 'controlador/AuthProxy.php';
+            $controllerInstance = new AuthProxy($controllerInstance);
+        }
         $controllerInstance->handleRequest();
         exit; // Detiene aquí para evitar que cargue el HTML debajo
     } else {

--- a/modelo/MUsuario.php
+++ b/modelo/MUsuario.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../config/conexion.php';
+
+class MUsuario {
+    private $pdo;
+
+    public function __construct() {
+        $this->pdo = Conexion::conectar();
+    }
+
+    public function obtenerUsuarioPorUsername($username) {
+        $stmt = $this->pdo->prepare('SELECT * FROM usuario WHERE username = :username');
+        $stmt->execute([':username' => $username]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function crearUsuario($username, $passwordHash, $rol) {
+        $sql = 'INSERT INTO usuario (username, password, rol) VALUES (:username, :password, :rol)';
+        $stmt = $this->pdo->prepare($sql);
+        return $stmt->execute([
+            ':username' => $username,
+            ':password' => $passwordHash,
+            ':rol' => $rol
+        ]);
+    }
+}
+?>

--- a/vista/auth/VLogin.php
+++ b/vista/auth/VLogin.php
@@ -1,0 +1,32 @@
+<?php
+class VLogin {
+    public function render($error = '') {
+        $pageTitle = 'Iniciar Sesión';
+        require_once __DIR__ . '/../componentes/header.php';
+        require_once __DIR__ . '/../componentes/navbar.php';
+        ?>
+        <div class="container mt-4">
+            <h1>Iniciar Sesión</h1>
+            <?php if ($error): ?>
+                <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+            <?php endif; ?>
+            <div class="form-container">
+                <form action="index.php?controller=auth&action=login" method="POST">
+                    <div class="mb-3">
+                        <label class="form-label">Usuario</label>
+                        <input type="text" name="username" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Contraseña</label>
+                        <input type="password" name="password" class="form-control" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Entrar</button>
+                </form>
+            </div>
+        </div>
+        </body>
+        </html>
+        <?php
+    }
+}
+?>

--- a/vista/componentes/navbar.php
+++ b/vista/componentes/navbar.php
@@ -34,7 +34,11 @@
                 </li>
             </ul>
             <div class="navbar-text">
-                <a href="#" class="text-white">Cerrar Sesión</a>
+                <?php if (isset($_SESSION['usuario'])): ?>
+                    <a href="index.php?controller=auth&action=logout" class="text-white">Cerrar Sesión</a>
+                <?php else: ?>
+                    <a href="index.php?controller=auth&action=login" class="text-white">Iniciar Sesión</a>
+                <?php endif; ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- extend initial SQL script with `usuario` table and admin user
- create authentication model and controllers
- protect controllers behind AuthProxy
- add login view and update navbar
- update index.php to bootstrap authentication

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684209ca4cb4832197a01220111ccc55