### PR TITLE
Decouple routing logic via Client class

### DIFF
--- a/cliente/Client.php
+++ b/cliente/Client.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../config/conexion.php';
+require_once __DIR__ . '/../controlador/AuthProxy.php';
+
+class Client {
+    public function handle() {
+        $controller = $_GET['controller'] ?? null;
+        if ($controller) {
+            $controllerClass = 'C' . ucfirst($controller);
+            $controllerFile = __DIR__ . '/../controlador/' . $controllerClass . '.php';
+
+            if (file_exists($controllerFile)) {
+                require_once $controllerFile;
+                $controllerInstance = new $controllerClass();
+                if ($controller !== 'auth') {
+                    $controllerInstance = new AuthProxy($controllerInstance);
+                }
+                $controllerInstance->handleRequest();
+                return true;
+            } else {
+                die("❌ Controlador no encontrado: $controllerClass");
+            }
+        }
+        return false;
+    }
+}
+?>

--- a/index.php
+++ b/index.php
@@ -2,27 +2,12 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-require_once 'config/conexion.php';
+require_once 'cliente/Client.php';
 session_start();
 
-$controller = $_GET['controller'] ?? null;
-
-if ($controller) {
-    $controllerClass = 'C' . ucfirst($controller);
-    $controllerFile = "controlador/{$controllerClass}.php";
-
-    if (file_exists($controllerFile)) {
-        require_once $controllerFile;
-        $controllerInstance = new $controllerClass();
-        if ($controller !== 'auth') {
-            require_once 'controlador/AuthProxy.php';
-            $controllerInstance = new AuthProxy($controllerInstance);
-        }
-        $controllerInstance->handleRequest();
-        exit; // Detiene aquí para evitar que cargue el HTML debajo
-    } else {
-        die("❌ Controlador no encontrado: $controllerClass");
-    }
+$client = new Client();
+if ($client->handle()) {
+    exit; // Detiene aquí para evitar que cargue el HTML debajo
 }
 ?>
 


### PR DESCRIPTION
## Summary
- create `cliente/Client.php` to centralize controller routing with `AuthProxy`
- update `index.php` to use the new Client class

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841848b49bc83219792b620caa785fc