### PR TITLE
Fix session check in AuthProxy

### DIFF
--- a/controlador/AuthProxy.php
+++ b/controlador/AuthProxy.php
@@ -9,6 +9,10 @@ class AuthProxy implements IController {
     }
 
     public function handleRequest() {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
         if (isset($_SESSION['usuario'])) {
             $this->controller->handleRequest();
         } else {


### PR DESCRIPTION
## Summary
- check `session_status()` before referencing `$_SESSION`
- ensure `session_start()` runs in `AuthProxy` before checking auth

## Testing
- `php -l controlador/AuthProxy.php`
- `find controlador -name '*.php' -print0 | xargs -0 php -l`

------
https://chatgpt.com/codex/tasks/task_e_684df5c8acb08321ac489e4298a46173