### PR TITLE
Implement observer pattern for Evento

### DIFF
--- a/controlador/CEvento.php
+++ b/controlador/CEvento.php
@@ -4,6 +4,8 @@ require_once __DIR__ . '/../modelo/MCategoria_evento.php';
 require_once __DIR__ . '/../modelo/MMiembro.php';
 require_once __DIR__ . '/../modelo/MCargo.php';
 require_once __DIR__ . '/../modelo/MAsistencia_Evento.php';
+require_once __DIR__ . '/../observador/LoggerObserver.php';
+require_once __DIR__ . '/../observador/EmailObserver.php';
 require_once __DIR__ . '/../vista/eventos/VEvento.php';
 require_once __DIR__ . '/IController.php';
 
@@ -17,6 +19,8 @@ class CEvento implements IController {
         $this->modelo = new MEvento();
         $this->modeloCategoria = new MCategoria_evento();
         $this->vista = new VEvento();
+        $this->modelo->attach(new LoggerObserver());
+        $this->modelo->attach(new EmailObserver());
     }
 
     public function handleRequest() {

--- a/observador/EmailObserver.php
+++ b/observador/EmailObserver.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/EventoObserver.php';
+
+class EmailObserver implements EventoObserver {
+    private $file;
+
+    public function __construct($file = __DIR__ . '/../logs/email.log') {
+        $this->file = $file;
+    }
+
+    public function update(int $eventoId, array $data) {
+        $mensaje = date('Y-m-d H:i:s') . " Email enviado para evento $eventoId" . PHP_EOL;
+        file_put_contents($this->file, $mensaje, FILE_APPEND);
+    }
+}
+?>

--- a/observador/EventoObserver.php
+++ b/observador/EventoObserver.php
@@ -1,0 +1,5 @@
+<?php
+interface EventoObserver {
+    public function update(int $eventoId, array $data);
+}
+?>

--- a/observador/LoggerObserver.php
+++ b/observador/LoggerObserver.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/EventoObserver.php';
+
+class LoggerObserver implements EventoObserver {
+    private $file;
+
+    public function __construct($file = __DIR__ . '/../logs/evento.log') {
+        $this->file = $file;
+    }
+
+    public function update(int $eventoId, array $data) {
+        $mensaje = date('Y-m-d H:i:s') . " Evento $eventoId: " . json_encode($data) . PHP_EOL;
+        file_put_contents($this->file, $mensaje, FILE_APPEND);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add `EventoObserver` interface and example observers
- extend `MEvento` to manage observers and notify on CRUD operations
- register `LoggerObserver` and `EmailObserver` in `CEvento`
- keep logs under new `logs` directory

## Testing
- `php -l observador/EventoObserver.php` *(fails: php not installed)*
- `php -l observador/LoggerObserver.php` *(fails: php not installed)*
- `php -l observador/EmailObserver.php` *(fails: php not installed)*
- `php -l modelo/MEvento.php` *(fails: php not installed)*
- `php -l controlador/CEvento.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e19d237d48321b86e3974c2977eb6