### PR TITLE
Refactor controller creation via factory

### DIFF
--- a/cliente/Client.php
+++ b/cliente/Client.php
@@ -1,25 +1,20 @@
 <?php
 require_once __DIR__ . '/../config/conexion.php';
-require_once __DIR__ . '/../controlador/AuthProxy.php';
+require_once __DIR__ . '/ControllerFactory.php';
 
 class Client {
+    private $factory;
+
+    public function __construct() {
+        $this->factory = new ControllerFactory();
+    }
+
     public function handle() {
         $controller = $_GET['controller'] ?? null;
         if ($controller) {
-            $controllerClass = 'C' . ucfirst($controller);
-            $controllerFile = __DIR__ . '/../controlador/' . $controllerClass . '.php';
-
-            if (file_exists($controllerFile)) {
-                require_once $controllerFile;
-                $controllerInstance = new $controllerClass();
-                if ($controller !== 'auth') {
-                    $controllerInstance = new AuthProxy($controllerInstance);
-                }
-                $controllerInstance->handleRequest();
-                return true;
-            } else {
-                die("❌ Controlador no encontrado: $controllerClass");
-            }
+            $controllerInstance = $this->factory->create($controller);
+            $controllerInstance->handleRequest();
+            return true;
         }
         return false;
     }

--- a/cliente/ControllerFactory.php
+++ b/cliente/ControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../controlador/IController.php';
+require_once __DIR__ . '/../controlador/AuthProxy.php';
+
+class ControllerFactory {
+    public function create(string $name): IController {
+        $controllerClass = 'C' . ucfirst($name);
+        $controllerFile = __DIR__ . '/../controlador/' . $controllerClass . '.php';
+
+        if (!file_exists($controllerFile)) {
+            die("\u274c Controlador no encontrado: $controllerClass");
+        }
+
+        require_once $controllerFile;
+
+        if (!class_exists($controllerClass)) {
+            die("\u274c Clase de controlador no existe: $controllerClass");
+        }
+
+        $instance = new $controllerClass();
+
+        if ($name !== 'auth') {
+            $instance = new AuthProxy($instance);
+        }
+
+        return $instance;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- introduce `ControllerFactory` for building controller instances
- use `ControllerFactory` in `Client` to centralize controller setup

## Testing
- `php -l cliente/ControllerFactory.php`
- `php -l cliente/Client.php`


------
https://chatgpt.com/codex/tasks/task_e_684e19cfefa08321a0504cddbcded10b