### PR TITLE
Add RoleProxy and controller factory

### DIFF
--- a/cliente/Client.php
+++ b/cliente/Client.php
@@ -1,25 +1,14 @@
 <?php
 require_once __DIR__ . '/../config/conexion.php';
-require_once __DIR__ . '/../controlador/AuthProxy.php';
+require_once __DIR__ . '/../config/ControllerFactory.php';
 
 class Client {
     public function handle() {
         $controller = $_GET['controller'] ?? null;
         if ($controller) {
-            $controllerClass = 'C' . ucfirst($controller);
-            $controllerFile = __DIR__ . '/../controlador/' . $controllerClass . '.php';
-
-            if (file_exists($controllerFile)) {
-                require_once $controllerFile;
-                $controllerInstance = new $controllerClass();
-                if ($controller !== 'auth') {
-                    $controllerInstance = new AuthProxy($controllerInstance);
-                }
-                $controllerInstance->handleRequest();
-                return true;
-            } else {
-                die("❌ Controlador no encontrado: $controllerClass");
-            }
+            $instance = ControllerFactory::create($controller);
+            $instance->handleRequest();
+            return true;
         }
         return false;
     }

--- a/config/ControllerFactory.php
+++ b/config/ControllerFactory.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/../controlador/AuthProxy.php';
+require_once __DIR__ . '/../controlador/RoleProxy.php';
+
+class ControllerFactory {
+    private static $roleMap = [
+        'contribucion' => ['admin'],
+        'cargo' => ['admin'],
+        'evento' => ['admin'],
+        'categoria_evento' => ['admin'],
+        'asignacion_ministerio' => ['admin'],
+    ];
+
+    public static function create(string $controllerName) {
+        $controllerClass = 'C' . ucfirst($controllerName);
+        $controllerFile = __DIR__ . '/../controlador/' . $controllerClass . '.php';
+
+        if (!file_exists($controllerFile)) {
+            die("❌ Controlador no encontrado: $controllerClass");
+        }
+
+        require_once $controllerFile;
+        $controller = new $controllerClass();
+
+        if ($controllerName !== 'auth') {
+            $controller = new AuthProxy($controller);
+        }
+
+        if (isset(self::$roleMap[$controllerName])) {
+            $controller = new RoleProxy($controller, self::$roleMap[$controllerName]);
+        }
+
+        return $controller;
+    }
+}
+?>

--- a/controlador/RoleProxy.php
+++ b/controlador/RoleProxy.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/IController.php';
+
+class RoleProxy implements IController {
+    private $controller;
+    private $roles;
+
+    public function __construct(IController $controller, array $roles) {
+        $this->controller = $controller;
+        $this->roles = $roles;
+    }
+
+    public function handleRequest() {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION['usuario'])) {
+            header('Location: index.php?controller=auth&action=login');
+            exit;
+        }
+
+        $rol = $_SESSION['usuario']['rol'] ?? null;
+        if ($rol !== null && in_array($rol, $this->roles)) {
+            $this->controller->handleRequest();
+        } else {
+            header('HTTP/1.1 403 Forbidden');
+            echo 'Acceso no autorizado';
+            exit;
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add a `RoleProxy` controller wrapper for role-based checks
- create `ControllerFactory` to build controllers with proxies
- use the factory in `Client` for controller instantiation

## Testing
- `php -l controlador/RoleProxy.php`
- `php -l config/ControllerFactory.php`
- `php -l cliente/Client.php`


------
https://chatgpt.com/codex/tasks/task_e_684e19d143cc83219f3eeb13771a1991