### PR TITLE
Fix render method signatures

### DIFF
--- a/vista/auth/VLogin.php
+++ b/vista/auth/VLogin.php
@@ -2,9 +2,9 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VLogin extends VistaBase {
-    public function render($error = '') {
+    public function render(...$params) {
         $this->pageTitle = 'Iniciar Sesión';
-        parent::render($error);
+        parent::render(...$params);
     }
 
     protected function contenido($error = '') {

--- a/vista/congregacion/VAsignacion_Ministerio.php
+++ b/vista/congregacion/VAsignacion_Ministerio.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VAsignacion_Ministerio extends VistaBase {
-    public function render($asignaciones, $miembros, $ministerios, $asignacionEditar = null) {
+    public function render(...$params) {
+        $asignacionEditar = $params[3] ?? null;
         $this->pageTitle = isset($asignacionEditar) ? 'Editar Asignación Ministerio' : 'Registrar Asignación Ministerio';
-        parent::render($asignaciones, $miembros, $ministerios, $asignacionEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($asignaciones, $miembros, $ministerios, $asignacionEditar = null) {

--- a/vista/congregacion/VCargo.php
+++ b/vista/congregacion/VCargo.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VCargo extends VistaBase {
-    public function render($cargos = [], $cargoEditar = null) {
+    public function render(...$params) {
+        $cargoEditar = $params[1] ?? null;
         $this->pageTitle = isset($cargoEditar) ? 'Editar Cargo' : 'Registrar Cargo';
-        parent::render($cargos, $cargoEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($cargos = [], $cargoEditar = null) {

--- a/vista/congregacion/VMiembro.php
+++ b/vista/congregacion/VMiembro.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VMiembro extends VistaBase {
-    public function render($miembros = [], $cargos = [], $miembroEditar = null) {
+    public function render(...$params) {
+        $miembroEditar = $params[2] ?? null;
         $this->pageTitle = isset($miembroEditar) ? 'Editar Miembro' : 'Registrar Miembro';
-        parent::render($miembros, $cargos, $miembroEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($miembros = [], $cargos = [], $miembroEditar = null) {

--- a/vista/congregacion/VMinisterio.php
+++ b/vista/congregacion/VMinisterio.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VMinisterio extends VistaBase {
-    public function render($ministerios = [], $ministerioEditar = null) {
+    public function render(...$params) {
+        $ministerioEditar = $params[1] ?? null;
         $this->pageTitle = isset($ministerioEditar) ? 'Editar Ministerio' : 'Registrar Ministerio';
-        parent::render($ministerios, $ministerioEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($ministerios = [], $ministerioEditar = null) {

--- a/vista/contribuciones/VContribucion.php
+++ b/vista/contribuciones/VContribucion.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VContribucion extends VistaBase {
-    public function render($contribuciones, $miembros, $eventos, $contribucionEditar = null) {
+    public function render(...$params) {
+        $contribucionEditar = $params[3] ?? null;
         $this->pageTitle = isset($contribucionEditar) ? 'Editar Contribución' : 'Registrar Contribución';
-        parent::render($contribuciones, $miembros, $eventos, $contribucionEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($contribuciones, $miembros, $eventos, $contribucionEditar = null) {

--- a/vista/eventos/VCategoria_evento.php
+++ b/vista/eventos/VCategoria_evento.php
@@ -2,9 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VCategoria_evento extends VistaBase {
-    public function render($categorias = [], $categoriaEditar = null) {
+    public function render(...$params) {
+        $categoriaEditar = $params[1] ?? null;
         $this->pageTitle = isset($categoriaEditar) ? 'Editar Categoría de Evento' : 'Registrar Categoría de Evento';
-        parent::render($categorias, $categoriaEditar);
+        parent::render(...$params);
     }
 
     protected function contenido($categorias = [], $categoriaEditar = null) {

--- a/vista/eventos/VEvento.php
+++ b/vista/eventos/VEvento.php
@@ -2,17 +2,10 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VEvento extends VistaBase {
-    public function render(
-        $eventos,
-        $categorias,
-        $form_evento = [],
-        $eventoEditar = null,
-        $miembros = [],
-        $cargos = [],
-        $asistentes_evento = []
-    ) {
+    public function render(...$params) {
+        $eventoEditar = $params[3] ?? null;
         $this->pageTitle = isset($eventoEditar) ? 'Editar Evento' : 'Registrar Evento';
-        parent::render($eventos, $categorias, $form_evento, $eventoEditar, $miembros, $cargos, $asistentes_evento);
+        parent::render(...$params);
     }
 
     protected function contenido(


### PR DESCRIPTION
## Summary
- make all view classes use variadic parameters for `render`
- set page title based on the optional edit param

## Testing
- `php -l vista/eventos/VEvento.php`
- `php -l vista/congregacion/VAsignacion_Ministerio.php`


------
https://chatgpt.com/codex/tasks/task_e_684e3182ab008321bcd673255eabe2b1