### PR TITLE
Fix view method compatibility

### DIFF
--- a/vista/auth/VLogin.php
+++ b/vista/auth/VLogin.php
@@ -2,12 +2,13 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VLogin extends VistaBase {
-    public function render($error = '') {
+    public function render(...$params) {
         $this->pageTitle = 'Iniciar Sesión';
-        parent::render($error);
+        parent::render(...$params);
     }
 
-    protected function contenido($error = '') {
+    protected function contenido(...$params) {
+        $error = $params[0] ?? '';
         ?>
         <div class="container mt-4">
             <div class="row justify-content-center">

--- a/vista/congregacion/VAsignacion_Ministerio.php
+++ b/vista/congregacion/VAsignacion_Ministerio.php
@@ -2,12 +2,17 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VAsignacion_Ministerio extends VistaBase {
-    public function render($asignaciones, $miembros, $ministerios, $asignacionEditar = null) {
+    public function render(...$params) {
+        $asignacionEditar = $params[3] ?? null;
         $this->pageTitle = isset($asignacionEditar) ? 'Editar Asignación Ministerio' : 'Registrar Asignación Ministerio';
-        parent::render($asignaciones, $miembros, $ministerios, $asignacionEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($asignaciones, $miembros, $ministerios, $asignacionEditar = null) {
+    protected function contenido(...$params) {
+        $asignaciones = $params[0] ?? [];
+        $miembros = $params[1] ?? [];
+        $ministerios = $params[2] ?? [];
+        $asignacionEditar = $params[3] ?? null;
         $isEditing = isset($asignacionEditar);
         ?>
         <div class="container mt-4">

--- a/vista/congregacion/VCargo.php
+++ b/vista/congregacion/VCargo.php
@@ -2,12 +2,15 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VCargo extends VistaBase {
-    public function render($cargos = [], $cargoEditar = null) {
+    public function render(...$params) {
+        $cargoEditar = $params[1] ?? null;
         $this->pageTitle = isset($cargoEditar) ? 'Editar Cargo' : 'Registrar Cargo';
-        parent::render($cargos, $cargoEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($cargos = [], $cargoEditar = null) {
+    protected function contenido(...$params) {
+        $cargos = $params[0] ?? [];
+        $cargoEditar = $params[1] ?? null;
         $isEditing = isset($cargoEditar);
         ?>
         <div class="container mt-4">

--- a/vista/congregacion/VMiembro.php
+++ b/vista/congregacion/VMiembro.php
@@ -2,12 +2,16 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VMiembro extends VistaBase {
-    public function render($miembros = [], $cargos = [], $miembroEditar = null) {
+    public function render(...$params) {
+        $miembroEditar = $params[2] ?? null;
         $this->pageTitle = isset($miembroEditar) ? 'Editar Miembro' : 'Registrar Miembro';
-        parent::render($miembros, $cargos, $miembroEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($miembros = [], $cargos = [], $miembroEditar = null) {
+    protected function contenido(...$params) {
+        $miembros = $params[0] ?? [];
+        $cargos = $params[1] ?? [];
+        $miembroEditar = $params[2] ?? null;
         $isEditing = isset($miembroEditar);
         ?>
         <div class="container mt-4">

--- a/vista/congregacion/VMinisterio.php
+++ b/vista/congregacion/VMinisterio.php
@@ -2,12 +2,15 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VMinisterio extends VistaBase {
-    public function render($ministerios = [], $ministerioEditar = null) {
+    public function render(...$params) {
+        $ministerioEditar = $params[1] ?? null;
         $this->pageTitle = isset($ministerioEditar) ? 'Editar Ministerio' : 'Registrar Ministerio';
-        parent::render($ministerios, $ministerioEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($ministerios = [], $ministerioEditar = null) {
+    protected function contenido(...$params) {
+        $ministerios = $params[0] ?? [];
+        $ministerioEditar = $params[1] ?? null;
         $isEditing = isset($ministerioEditar);
         ?>
         <div class="container mt-4">

--- a/vista/contribuciones/VContribucion.php
+++ b/vista/contribuciones/VContribucion.php
@@ -2,12 +2,17 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VContribucion extends VistaBase {
-    public function render($contribuciones, $miembros, $eventos, $contribucionEditar = null) {
+    public function render(...$params) {
+        $contribucionEditar = $params[3] ?? null;
         $this->pageTitle = isset($contribucionEditar) ? 'Editar Contribución' : 'Registrar Contribución';
-        parent::render($contribuciones, $miembros, $eventos, $contribucionEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($contribuciones, $miembros, $eventos, $contribucionEditar = null) {
+    protected function contenido(...$params) {
+        $contribuciones = $params[0] ?? [];
+        $miembros = $params[1] ?? [];
+        $eventos = $params[2] ?? [];
+        $contribucionEditar = $params[3] ?? null;
         $isEditing = isset($contribucionEditar);
         ?>
         <div class="container mt-4">

--- a/vista/eventos/VCategoria_evento.php
+++ b/vista/eventos/VCategoria_evento.php
@@ -2,12 +2,15 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VCategoria_evento extends VistaBase {
-    public function render($categorias = [], $categoriaEditar = null) {
+    public function render(...$params) {
+        $categoriaEditar = $params[1] ?? null;
         $this->pageTitle = isset($categoriaEditar) ? 'Editar Categoría de Evento' : 'Registrar Categoría de Evento';
-        parent::render($categorias, $categoriaEditar);
+        parent::render(...$params);
     }
 
-    protected function contenido($categorias = [], $categoriaEditar = null) {
+    protected function contenido(...$params) {
+        $categorias = $params[0] ?? [];
+        $categoriaEditar = $params[1] ?? null;
         $isEditing = isset($categoriaEditar);
         ?>
         <div class="container mt-4">

--- a/vista/eventos/VEvento.php
+++ b/vista/eventos/VEvento.php
@@ -2,28 +2,20 @@
 require_once __DIR__ . '/../VistaBase.php';
 
 class VEvento extends VistaBase {
-    public function render(
-        $eventos,
-        $categorias,
-        $form_evento = [],
-        $eventoEditar = null,
-        $miembros = [],
-        $cargos = [],
-        $asistentes_evento = []
-    ) {
+    public function render(...$params) {
+        $eventoEditar = $params[3] ?? null;
         $this->pageTitle = isset($eventoEditar) ? 'Editar Evento' : 'Registrar Evento';
-        parent::render($eventos, $categorias, $form_evento, $eventoEditar, $miembros, $cargos, $asistentes_evento);
+        parent::render(...$params);
     }
 
-    protected function contenido(
-        $eventos,
-        $categorias,
-        $form_evento = [],
-        $eventoEditar = null,
-        $miembros = [],
-        $cargos = [],
-        $asistentes_evento = []
-    ) {
+    protected function contenido(...$params) {
+        $eventos = $params[0] ?? [];
+        $categorias = $params[1] ?? [];
+        $form_evento = $params[2] ?? [];
+        $eventoEditar = $params[3] ?? null;
+        $miembros = $params[4] ?? [];
+        $cargos = $params[5] ?? [];
+        $asistentes_evento = $params[6] ?? [];
         $isEditing = isset($eventoEditar);
         ?>
         <div class="container mt-4">


### PR DESCRIPTION
## Summary
- update all `contenido` methods to accept variadic parameters
- use defaults to prevent warnings
- install php for linting

## Testing
- `php -l vista/auth/VLogin.php`
- `php -l vista/congregacion/VAsignacion_Ministerio.php`
- `php -l vista/congregacion/VCargo.php`
- `php -l vista/congregacion/VMiembro.php`
- `php -l vista/congregacion/VMinisterio.php`
- `php -l vista/contribuciones/VContribucion.php`
- `php -l vista/eventos/VCategoria_evento.php`
- `php -l vista/eventos/VEvento.php`


------
https://chatgpt.com/codex/tasks/task_e_684e3182ab008321bcd673255eabe2b1