### PR TITLE
Fix duplicate session_start warning

### DIFF
--- a/controlador/CEvento.php
+++ b/controlador/CEvento.php
@@ -24,7 +24,9 @@ class CEvento implements IController {
     }
 
     public function handleRequest() {
-        session_start();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $action = $_GET['action'] ?? 'listarEvento';
         switch ($action) {
             case 'crearEvento':


### PR DESCRIPTION
## Summary
- avoid calling `session_start()` when the session is already active

## Testing
- `php -l controlador/CEvento.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e5d79fc608321979d2f5d92fcd135