### PR TITLE
Fix tipo warning in contribution edit form

### DIFF
--- a/controlador/CContribucion.php
+++ b/controlador/CContribucion.php
@@ -46,7 +46,7 @@ class CContribucion implements IController {
             $this->modelo->crearContribucion(
                 $_POST['evento_id'] ?? null,
                 $_POST['miembro_id'],
-                $_POST['tipo'],
+                $_POST['tipo'] ?? null,
                 $_POST['monto'],
                 $_POST['fecha_registro'] ?? null
             );
@@ -66,7 +66,7 @@ class CContribucion implements IController {
                 $_POST['id'],
                 $_POST['evento_id'] ?? null,
                 $_POST['miembro_id'],
-                $_POST['tipo'],
+                $_POST['tipo'] ?? null,
                 $_POST['monto'],
                 $_POST['fecha_registro'] ?? null
             );

--- a/controlador/CEvento.php
+++ b/controlador/CEvento.php
@@ -24,7 +24,9 @@ class CEvento implements IController {
     }
 
     public function handleRequest() {
-        session_start();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $action = $_GET['action'] ?? 'listarEvento';
         switch ($action) {
             case 'crearEvento':

--- a/vista/contribuciones/VContribucion.php
+++ b/vista/contribuciones/VContribucion.php
@@ -47,6 +47,15 @@ class VContribucion extends VistaBase {
                         </select>
                     </div>
                     <div class="mb-3">
+                        <label class="form-label">Tipo</label>
+                        <select name="tipo" class="form-select" required>
+                            <option value="">Seleccione un tipo</option>
+                            <option value="Diezmo" <?= $isEditing && $contribucionEditar['tipo'] === 'Diezmo' ? 'selected' : '' ?>>Diezmo</option>
+                            <option value="Ofrenda" <?= $isEditing && $contribucionEditar['tipo'] === 'Ofrenda' ? 'selected' : '' ?>>Ofrenda</option>
+                            <option value="Donacion" <?= $isEditing && $contribucionEditar['tipo'] === 'Donacion' ? 'selected' : '' ?>>Donaci&oacute;n</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
                         <label class="form-label">Monto</label>
                         <input type="number" step="0.01" name="monto" class="form-control" value="<?= $isEditing ? htmlspecialchars($contribucionEditar['monto']) : '' ?>" required>
                     </div>


### PR DESCRIPTION
## Summary
- add a `tipo` dropdown to the contribution form so POST data includes `tipo`
- check for `tipo` key before sending it to the model

## Testing
- `php -l vista/contribuciones/VContribucion.php` *(fails: `php` not installed)*
- `php -l controlador/CContribucion.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e5d79fc608321979d2f5d92fcd135