### PR TITLE
Add WhatsApp observer for events

### DIFF
--- a/config/twilio.php
+++ b/config/twilio.php
@@ -1,0 +1,7 @@
+<?php
+class TwilioConfig {
+    public static $sid = 'YOUR_TWILIO_SID';
+    public static $token = 'YOUR_TWILIO_TOKEN';
+    public static $from = 'YOUR_TWILIO_WHATSAPP_NUMBER';
+}
+?>

--- a/controlador/CEvento.php
+++ b/controlador/CEvento.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../modelo/MCargo.php';
 require_once __DIR__ . '/../modelo/MAsistencia_Evento.php';
 require_once __DIR__ . '/../observador/LoggerObserver.php';
 require_once __DIR__ . '/../observador/EmailObserver.php';
+require_once __DIR__ . '/../observador/WhatsAppObserver.php';
 require_once __DIR__ . '/../vista/eventos/VEvento.php';
 require_once __DIR__ . '/IController.php';
 
@@ -21,6 +22,7 @@ class CEvento implements IController {
         $this->vista = new VEvento();
         $this->modelo->attach(new LoggerObserver());
         $this->modelo->attach(new EmailObserver());
+        $this->modelo->attach(new WhatsAppObserver());
     }
 
     public function handleRequest() {
@@ -95,12 +97,14 @@ class CEvento implements IController {
             }
             // Si se presiona 'guardar_evento'
             if (isset($_POST['guardar_evento'])) {
+                $miembrosIds = array_column($_SESSION['asistentes_evento'], 'miembro_id');
                 $evento_id = $this->modelo->crearEvento(
                     $_POST['categoria_id'],
                     $_POST['nombre'],
                     $_POST['fecha_inicio'],
                     $_POST['fecha_final'],
-                    $_POST['lugar'] ?? ''
+                    $_POST['lugar'] ?? '',
+                    $miembrosIds
                 );
                 foreach ($_SESSION['asistentes_evento'] as $asistente) {
                     $modeloAsistencia->agregarAsistente(

--- a/modelo/MEvento.php
+++ b/modelo/MEvento.php
@@ -34,7 +34,7 @@ class MEvento
     }
 
     // CREATE
-    public function crearEvento($categoria_id, $nombre, $fecha_inicio, $fecha_final, $lugar)
+    public function crearEvento($categoria_id, $nombre, $fecha_inicio, $fecha_final, $lugar, array $miembros_ids = [])
     {
         $sql = "INSERT INTO evento (categoria_id, nombre, fecha_inicio, fecha_final, lugar) VALUES (:categoria_id, :nombre, :fecha_inicio, :fecha_final, :lugar)";
         $stmt = $this->pdo->prepare($sql);
@@ -54,7 +54,8 @@ class MEvento
                 'fecha_inicio' => $fecha_inicio,
                 'fecha_final' => ($fecha_final === '' ? null : $fecha_final),
                 'lugar' => $lugar
-            ]
+            ],
+            'miembros_ids' => $miembros_ids
         ]);
         return $id;
     }

--- a/observador/WhatsAppObserver.php
+++ b/observador/WhatsAppObserver.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/EventoObserver.php';
+require_once __DIR__ . '/../modelo/MMiembro.php';
+require_once __DIR__ . '/../config/twilio.php';
+
+class WhatsAppObserver implements EventoObserver {
+    private $sid;
+    private $token;
+    private $from;
+
+    public function __construct($sid = null, $token = null, $from = null) {
+        $this->sid = $sid ?? TwilioConfig::$sid;
+        $this->token = $token ?? TwilioConfig::$token;
+        $this->from = $from ?? TwilioConfig::$from;
+    }
+
+    public function update(int $eventoId, array $data) {
+        if ($data['accion'] !== 'crear') {
+            return;
+        }
+        if (empty($data['miembros_ids'])) {
+            return;
+        }
+        $miembroModel = new MMiembro();
+        foreach ($data['miembros_ids'] as $miembroId) {
+            $miembro = $miembroModel->obtenerMiembroPorId($miembroId);
+            if (!$miembro || empty($miembro['telefono'])) {
+                continue;
+            }
+            $mensaje = 'Nuevo evento: ' . $data['datos']['nombre'];
+            $this->enviarWhatsApp($miembro['telefono'], $mensaje);
+        }
+    }
+
+    private function enviarWhatsApp($toNumber, $message) {
+        $url = 'https://api.twilio.com/2010-04-01/Accounts/' . $this->sid . '/Messages.json';
+        $postFields = http_build_query([
+            'From' => 'whatsapp:' . $this->from,
+            'To' => 'whatsapp:' . $toNumber,
+            'Body' => $message
+        ]);
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
+        curl_setopt($ch, CURLOPT_USERPWD, $this->sid . ':' . $this->token);
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- configure Twilio credentials
- implement new `WhatsAppObserver` to send messages when events are created
- hook the observer into the event controller
- provide attendee IDs to observers on event creation

## Testing
- `php -l observador/WhatsAppObserver.php` *(fails: `php` not found)*
- `php -l modelo/MEvento.php` *(fails: `php` not found)*
- `php -l controlador/CEvento.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ecee5b48321b6c017e8239b5ce1